### PR TITLE
Fix Keys - Not in a Container

### DIFF
--- a/Source/Networking/SITSerialization.cs
+++ b/Source/Networking/SITSerialization.cs
@@ -69,16 +69,31 @@ namespace StayInTarkov.Networking
         {
             public static void SerializeGridItemAddressDescriptor(NetDataWriter writer, GridItemAddressDescriptor gridItemAddressDescriptor)
             {
-                SerializeLocationInGrid(writer, gridItemAddressDescriptor.LocationInGrid);
+                if (gridItemAddressDescriptor != null) { 
+                    SerializeLocationInGrid(writer, gridItemAddressDescriptor.LocationInGrid);
+                }
+                else //Write the value as -1 which is an invalid location so deserilize will skip
+                {
+                    writer.Put(-1);
+                }
             }
 
             public static GridItemAddressDescriptor DeserializeGridItemAddressDescriptor(NetDataReader reader)
             {
-                return new GridItemAddressDescriptor()
+                //Check for -1 as the first value, if so the GridItem doesn't exist
+                if (reader.GetInt() == -1)
                 {
-                    LocationInGrid = DeserializeLocationInGrid(reader),
-                    Container = DeserializeContainerDescriptor(reader)
-                };
+                    return null;
+                }
+                else {
+                    //Set the DataReader packet back one integer so GridItem can re-read it.
+                    reader.SetPosition(reader.Position - sizeof(int));
+                    return new GridItemAddressDescriptor()
+                    {
+                        LocationInGrid = DeserializeLocationInGrid(reader),
+                        Container = DeserializeContainerDescriptor(reader)
+                    };
+                }
             }
 
             public static void SerializeContainerDescriptor(NetDataWriter writer, ContainerDescriptor containerDescriptor)


### PR DESCRIPTION
Gilded Key Mod does this. DoorPatch checks for a container before creating the serializable GridItem's, but didn't catch the null value before serialization.

Ideally I would have used a variable for -1 integer instead of magic number, but it needs to be a valid integer outside the range of a container # of X locations.